### PR TITLE
Documentation: restructure README, create a guide for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Guide for Contributors
+We thank you for choosing to devote your time to further Eve's development this Hacktoberfest. In order to maintain a consistent and healthy ecosystem, we ask that you read and adhere to the following guidelines. These guidelines pertain to how you should go about contributing to this project as a whole, and helps to ensure that this Hacktoberfest ends well.
+
+# Setting up the Project
+1. To clone the project and set it up in your local environment, make sure that you have Node.js v(x.x.x) installed, as well as NPM and [TypeScript](https://www.typescriptlang.org/).
+
+2. Next, make a bot application through Discord's developer panel. [How-to GIF](https://i.imgur.com/DZbIwMD.gif). *Keep the token to yourself, but copy it for later.*
+
+2. Next, clone the repository using `git clone https://github.com/Vimposed/eve`. 
+(Alternatively, `git@github.com:Vimposed/eve.git` for SSH, or `gh repo clone Vimposed/eve` for GitHub CLI.)
+
+3. In the `src` directory, rename `config.example.ts` to `config.ts`. Then, fill out the necessary fields - `token` and `mongo` (`prefix` is optional, but you may want to change the user ID to yours in `owners`) - with the token you copied earlier and the MongoDB information. 
+*(Mongo setup GIF, @scrap?)*
+
+4. Lastly, run `npm run dev` and your bot should be online for testing!
+
+## Guidelines
+
+1. **Ensure that your titles and explanations are concise and well-articulated.**
+
+2. **Propose proactive changes.**
+
+3. **No antagonistic behaviour.**

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# eve
+# Eve
 
-git clone https://github.com/Vimposed/eve/
+**Eve** is a semi-private server management bot for [Discord](https://discord.com). It features a suite of advanced tools to help streamline the server administration, moderation, and auto-moderation processes. In addition to this, they are also intended to be extremely intuitive, customizable, and fast.
 
-`npm install`
+The bot is semi-private in order to reduce load and keep it running smoothly. Our ultimate goal with Eve is to make a functional bot that delivers excellent tools and performance in one package.
 
-rename `src/config.example.ts` to `src/config.ts`
+## Contributing
 
-and then edit the `config.ts` with the givien credentials.
+If you'd like to contribute to the Eve project, and support our mission to create a fast-performing, advanced Discord bot, please check out our [Contributor's Guide](https://github.com/Vimposed/eve/blob/master/CONTRIBUTING.md).
 
-afterwards run `npm run dev`
+# License
+
+Eve is licensed under the [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html) license. If you plan on using this project's source code, please read and understand the license first. A summary of the license can be found [here](https://github.com/Vimposed/eve/blob/master/LICENSE).


### PR DESCRIPTION
As per the changes listed in the title, I have completely restructured the README and moved the set-up instructions (among other things) to CONTRIBUTING.md. 

This is on a new branch because the contributing guide has not yet been finalized. Before we push to master, I request that you add a MongoDB setup guide, and read over the two new files for typos or things I may have missed.